### PR TITLE
ALS-3852: Limit values returned in TopmedVariable

### DIFF
--- a/tagging/configs/dictionary_control_file.csv
+++ b/tagging/configs/dictionary_control_file.csv
@@ -46,6 +46,7 @@ MESA,phs001416,/local/source/phs001416/rawData/,DBGAPDictionaryModel
 MGHAF,phs001001,/local/source/phs001001/rawData/,DBGAPDictionaryModel
 MGHAF,phs001062,/local/source/phs001062/rawData/,DBGAPDictionaryModel
 MSH,phs002348,/local/source/phs002348/rawData/,DefaultJsonDictionaryModel
+NSRR_CFS,phs002715,/local/source/phs002715/rawData/,DefaultJsonDictionaryModel
 ORCHID,phs002299,/local/source/phs002299/rawData/,DefaultJsonDictionaryModel
 PARTNERS,phs001024,/local/source/phs001024/rawData/,DBGAPDictionaryModel
 PCGC,phs001194,/local/source/phs001194/rawData/,DBGAPDictionaryModel

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TagSearchResource.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TagSearchResource.java
@@ -112,7 +112,7 @@ public class TagSearchResource implements IResourceRS {
         List<SearchResult> searchResults = results.entrySet().stream()
                 .flatMap(entry -> entry.getValue().stream()
                         .map(topmedVariable -> {
-                            if (topmedVariable.getValues().size() > 0 && searchQuery.getVariableValuesLimit() != null && searchQuery.getVariableValuesLimit() > 0) {
+                            if (searchQuery.getVariableValuesLimit() != null && searchQuery.getVariableValuesLimit() > topmedVariable.getValues().size()) {
                                 return topmedVariable.copy(searchQuery.getVariableValuesLimit());
                             }
                             return topmedVariable;

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TagSearchResource.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TagSearchResource.java
@@ -112,7 +112,7 @@ public class TagSearchResource implements IResourceRS {
         List<SearchResult> searchResults = results.entrySet().stream()
                 .flatMap(entry -> entry.getValue().stream()
                         .map(topmedVariable -> {
-                            if (searchQuery.getVariableValuesLimit() != null && searchQuery.getVariableValuesLimit() > topmedVariable.getValues().size()) {
+                            if (searchQuery.getVariableValuesLimit() != null && searchQuery.getVariableValuesLimit() < topmedVariable.getValues().size()) {
                                 return topmedVariable.copy(searchQuery.getVariableValuesLimit());
                             }
                             return topmedVariable;

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TagSearchResource.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TagSearchResource.java
@@ -110,7 +110,14 @@ public class TagSearchResource implements IResourceRS {
 
         // flatten the results for each score into a list of search results
         List<SearchResult> searchResults = results.entrySet().stream()
-                .flatMap(entry -> entry.getValue().stream().map(topmedVariable -> new SearchResult(topmedVariable, entry.getKey())))
+                .flatMap(entry -> entry.getValue().stream()
+                        .map(topmedVariable -> {
+                            if (searchQuery.isExcludeVariableValues()) {
+                                return topmedVariable.setValues(new HashMap<>());
+                            }
+                            return topmedVariable;
+                        })
+                        .map(topmedVariable -> new SearchResult(topmedVariable, entry.getKey())))
                 .sorted(Comparator.comparing(SearchResult::getScore).reversed().thenComparing(result -> result.getResult().getMetadata().get("columnmeta_description")))
                 .collect(Collectors.toList());
 

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedDataTable.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedDataTable.java
@@ -18,10 +18,13 @@ public class TopmedDataTable implements Serializable {
 	 * 
 	 */
 	private static final long serialVersionUID = -2138670854234447527L;
-	public TreeMap<String, String> metadata;
-	public TreeMap<String, TopmedVariable> variables;
+	public SortedMap<String, String> metadata;
+	public SortedMap<String, TopmedVariable> variables;
+	/**
+	 * This field is enormous and should not be serialized
+	 */
 	@JsonIgnore
-	public HashMap<String, Set<TopmedVariable>> tagMap;
+	public Map<String, Set<TopmedVariable>> tagMap;
 
 	public TopmedDataTable(){
 		variables = new TreeMap<String, TopmedVariable>();

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedDataTable.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedDataTable.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.jsoup.nodes.Document;
 
 import com.google.common.collect.Sets;
@@ -19,6 +20,7 @@ public class TopmedDataTable implements Serializable {
 	private static final long serialVersionUID = -2138670854234447527L;
 	public TreeMap<String, String> metadata;
 	public TreeMap<String, TopmedVariable> variables;
+	@JsonIgnore
 	public HashMap<String, Set<TopmedVariable>> tagMap;
 
 	public TopmedDataTable(){

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedVariable.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedVariable.java
@@ -515,8 +515,9 @@ public class TopmedVariable implements Serializable  {
 		return values;
 	}
 
-	public void setValues(HashMap<String, String> values) {
+	public TopmedVariable setValues(HashMap<String, String> values) {
 		this.values = values;
+		return this;
 	}
 
 	public HashSet<String> getMetadata_tags() {

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedVariable.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedVariable.java
@@ -7,6 +7,7 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.jsoup.nodes.Element;
@@ -227,8 +228,11 @@ public class TopmedVariable implements Serializable  {
 			);
 	private Map<String, String> metadata = new HashMap<String, String>();
 	private Map<String, String> values = new HashMap<String, String>();
+	@JsonIgnore
 	private Set<String> metadata_tags = new HashSet<>();
+	@JsonIgnore
 	private Set<String> value_tags = new HashSet<>();
+	@JsonIgnore
 	public Set<String> allTagsLowercase = new HashSet<>();
 
 	private String studyId;

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedVariable.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedVariable.java
@@ -1,15 +1,14 @@
 package edu.harvard.hms.dbmi.avillach.hpds;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.jsoup.nodes.Element;
 
 import edu.harvard.hms.dbmi.avillach.hpds.etl.RawDataImporter.ColumnMetaCSVRecord;
@@ -226,11 +225,11 @@ public class TopmedVariable implements Serializable  {
 			"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
 			"yes"
 			);
-	private HashMap<String, String> metadata = new HashMap<String, String>();
+	private Map<String, String> metadata = new HashMap<String, String>();
 	private Map<String, String> values = new HashMap<String, String>();
-	private HashSet<String> metadata_tags = new HashSet<>();
-	private HashSet<String> value_tags = new HashSet<>();
-	public HashSet<String> allTagsLowercase = new HashSet<>();
+	private Set<String> metadata_tags = new HashSet<>();
+	private Set<String> value_tags = new HashSet<>();
+	public Set<String> allTagsLowercase = new HashSet<>();
 
 	private String studyId;
 	private String dtId;
@@ -503,7 +502,7 @@ public class TopmedVariable implements Serializable  {
 		return text.replaceAll("<a href.*>", "").replaceAll("</a>", "").replaceAll("&#39;", "'");
 	}
 
-	public HashMap<String, String> getMetadata() {
+	public Map<String, String> getMetadata() {
 		return metadata;
 	}
 
@@ -519,7 +518,7 @@ public class TopmedVariable implements Serializable  {
 		this.values = values;
 	}
 
-	public HashSet<String> getMetadata_tags() {
+	public Set<String> getMetadata_tags() {
 		return metadata_tags;
 	}
 
@@ -527,7 +526,7 @@ public class TopmedVariable implements Serializable  {
 		this.metadata_tags = metadata_tags;
 	}
 
-	public HashSet<String> getValue_tags() {
+	public Set<String> getValue_tags() {
 		return value_tags;
 	}
 
@@ -622,18 +621,19 @@ public class TopmedVariable implements Serializable  {
 		//  i.e. in TagSearchResource.fhsDictionary. We should create and use an immutable version of this object
 		//  for caching and including in service responses
 		TopmedVariable topmedVariable = new TopmedVariable();
-		topmedVariable.metadata = this.metadata;
+		topmedVariable.metadata = ImmutableMap.copyOf(this.metadata);
 
 		if (this.values.size() > valueLimit) {
-			topmedVariable.values = this.values.entrySet().stream()
+			Map<String, String> valuesCopy = this.values.entrySet().stream()
 					.limit(valueLimit)
 					.collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+			topmedVariable.values = ImmutableMap.copyOf(valuesCopy);
 		} else {
-			topmedVariable.values = new HashMap<>(this.values);
+			topmedVariable.values = ImmutableMap.copyOf(this.values);
 		}
-		topmedVariable.metadata_tags = this.metadata_tags;
-		topmedVariable.value_tags = this.value_tags;
-		topmedVariable.allTagsLowercase = this.allTagsLowercase;
+		topmedVariable.metadata_tags = ImmutableSet.copyOf(this.metadata_tags);
+		topmedVariable.value_tags = ImmutableSet.copyOf(this.value_tags);
+		topmedVariable.allTagsLowercase = ImmutableSet.copyOf(this.allTagsLowercase);
 		topmedVariable.studyId = this.studyId;
 		topmedVariable.dtId = this.dtId;
 		topmedVariable.varId = this.varId;

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedVariable.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedVariable.java
@@ -227,7 +227,7 @@ public class TopmedVariable implements Serializable  {
 			"yes"
 			);
 	private HashMap<String, String> metadata = new HashMap<String, String>();
-	private HashMap<String, String> values = new HashMap<String, String>();
+	private Map<String, String> values = new HashMap<String, String>();
 	private HashSet<String> metadata_tags = new HashSet<>();
 	private HashSet<String> value_tags = new HashSet<>();
 	public HashSet<String> allTagsLowercase = new HashSet<>();
@@ -511,13 +511,12 @@ public class TopmedVariable implements Serializable  {
 		this.metadata = metadata;
 	}
 
-	public HashMap<String, String> getValues() {
+	public Map<String, String> getValues() {
 		return values;
 	}
 
-	public TopmedVariable setValues(HashMap<String, String> values) {
+	public void setValues(HashMap<String, String> values) {
 		this.values = values;
-		return this;
 	}
 
 	public HashSet<String> getMetadata_tags() {
@@ -611,6 +610,38 @@ public class TopmedVariable implements Serializable  {
 
 	public void setIs_continuous(boolean is_continuous) {
 		this.is_continuous = is_continuous;
+	}
+
+	/**
+	 * Make a copy of this object.
+	 *
+	 * @param valueLimit maximum number of values to include in copy
+	 */
+	public TopmedVariable copy(int valueLimit) {
+		//  TODO: Since this object is not immutable, any changes to any of its fields will be reflected in any shared copies,
+		//  i.e. in TagSearchResource.fhsDictionary. We should create and use an immutable version of this object
+		//  for caching and including in service responses
+		TopmedVariable topmedVariable = new TopmedVariable();
+		topmedVariable.metadata = this.metadata;
+
+		if (this.values.size() > valueLimit) {
+			topmedVariable.values = this.values.entrySet().stream()
+					.limit(valueLimit)
+					.collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+		} else {
+			topmedVariable.values = new HashMap<>(this.values);
+		}
+		topmedVariable.metadata_tags = this.metadata_tags;
+		topmedVariable.value_tags = this.value_tags;
+		topmedVariable.allTagsLowercase = this.allTagsLowercase;
+		topmedVariable.studyId = this.studyId;
+		topmedVariable.dtId = this.dtId;
+		topmedVariable.varId = this.varId;
+		topmedVariable.is_categorical = this.is_categorical;
+		topmedVariable.is_continuous = this.is_continuous;
+		topmedVariable.lastInput = this.lastInput;
+		topmedVariable.lastScore = this.lastScore;
+		return topmedVariable;
 	}
 
 }

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedVariable.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/TopmedVariable.java
@@ -19,7 +19,7 @@ public class TopmedVariable implements Serializable  {
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 1802723843452332984L;
+	private static final long serialVersionUID = -317988926878698761L;
 	/**
 	 * This list should be deprecated and removed as this methodology is 
 	 * only used during data integration.  No other process should be using 
@@ -27,7 +27,7 @@ public class TopmedVariable implements Serializable  {
 	 * 
 	 */
 	@Deprecated
-	private static final List<String> EXCLUDED_WORDS_LIST = List.of(
+	private static final List<String> EXCLUDED_WORDS_LIST = ImmutableList.of(
 			"a",
 			"about",
 			"again",
@@ -59,7 +59,6 @@ public class TopmedVariable implements Serializable  {
 			"by",
 			"calculated",
 			"can",
-			"cardia",
 			"could",
 			"data",
 			"decimal",
@@ -85,7 +84,6 @@ public class TopmedVariable implements Serializable  {
 			"especially",
 			"etc",
 			"extracted",
-			"fhs",
 			"find",
 			"format",
 			"format",

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/etl/dict/serializer/HPDSDictionarySerializer.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/etl/dict/serializer/HPDSDictionarySerializer.java
@@ -2,9 +2,6 @@ package edu.harvard.hms.dbmi.avillach.hpds.etl.dict.serializer;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
@@ -168,7 +165,7 @@ public class HPDSDictionarySerializer {
 			} else {
 				for(String value: entry.getValue().values) {
 					
-					var.getValues().put(value,value);
+					var.getValues().add(value);
 				
 				}
 			}

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/etl/tags/TagBuilder.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/etl/tags/TagBuilder.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.cxf.helpers.FileUtils;
 
 import edu.harvard.hms.dbmi.avillach.hpds.TopmedDataTable;
@@ -27,7 +28,7 @@ import edu.harvard.hms.dbmi.avillach.hpds.TopmedVariable;
  */
 public class TagBuilder {
 
-	private static final List<String> EXCLUDED_WORDS_LIST = List.of(
+	private static final List<String> EXCLUDED_WORDS_LIST = ImmutableList.of(
 			"a",
 			"about",
 			"again",
@@ -59,7 +60,6 @@ public class TagBuilder {
 			"by",
 			"calculated",
 			"can",
-			"cardia",
 			"could",
 			"data",
 			"decimal",
@@ -85,7 +85,6 @@ public class TagBuilder {
 			"especially",
 			"etc",
 			"extracted",
-			"fhs",
 			"find",
 			"format",
 			"format",

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/etl/tags/TagBuilder.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/etl/tags/TagBuilder.java
@@ -284,7 +284,7 @@ public class TagBuilder {
 					}
 				});
 				// add values to metadata tags and value tags
-				for(String value: var.getValues().values()) {
+				for(String value: var.getValues()) {
 					try {
 						var.getValue_tags().addAll(TopmedVariable.class.getDeclaredConstructor().newInstance().filterTags(value.toUpperCase()));
 						var.getMetadata_tags().addAll(TopmedVariable.class.getDeclaredConstructor().newInstance().filterTags(value.toUpperCase()));

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/model/SearchQuery.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/model/SearchQuery.java
@@ -14,6 +14,6 @@ public class SearchQuery {
     private final String searchTerm;
     private final List<String> includedTags;
     private final List<String> excludedTags;
-    private final boolean returnTags;
+    private final boolean returnTags, excludeVariableValues;
     private final int offset, limit;
 }

--- a/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/model/SearchQuery.java
+++ b/tagging/src/main/java/edu/harvard/hms/dbmi/avillach/hpds/model/SearchQuery.java
@@ -14,6 +14,13 @@ public class SearchQuery {
     private final String searchTerm;
     private final List<String> includedTags;
     private final List<String> excludedTags;
-    private final boolean returnTags, excludeVariableValues;
+    private final boolean returnTags;
     private final int offset, limit;
+    /**
+     * Parameter to limit variable values returned. Using the following rules:
+     * NULL: return all variable values
+     * 0: return no variable values
+     * n > 0: return at most n variable values
+     */
+    private final Integer variableValuesLimit;
 }

--- a/tagging/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/TagSearchResourceTest.java
+++ b/tagging/src/test/java/edu/harvard/hms/dbmi/avillach/hpds/TagSearchResourceTest.java
@@ -1,0 +1,224 @@
+package edu.harvard.hms.dbmi.avillach.hpds;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.*;
+import edu.harvard.hms.dbmi.avillach.hpds.model.SearchQuery;
+import edu.harvard.hms.dbmi.avillach.hpds.model.TagSearchResponse;
+import edu.harvard.hms.dbmi.avillach.hpds.model.domain.SearchRequest;
+import edu.harvard.hms.dbmi.avillach.hpds.model.domain.SearchResults;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class TagSearchResourceTest {
+
+    private TagSearchResource tagSearchResource;
+
+    /**
+     * These are some basic mock objects, minimally populated. It should be safe to more fully flesh out these objects
+     * without breaking existing tests, although adding more TopmedVariable or TopmedDataTable may not be safe.
+     */
+    @Before
+    public void setUp() {
+        SortedMap<String, TopmedDataTable> dictionary = new TreeMap<>();
+
+        TopmedVariable variable1 = new TopmedVariable()
+                .setVarId("var1")
+                .setMetadata(ImmutableMap.of("columnmeta_description", "Chest Pain"));
+        variable1.allTagsLowercase = ImmutableSet.of("heart", "chest", "pain");
+
+        TopmedVariable variable2 = new TopmedVariable()
+                .setVarId("var2")
+                .setMetadata(ImmutableMap.of("columnmeta_description", "Afib"));
+        variable2.allTagsLowercase = ImmutableSet.of("heart", "attack", "afib");
+
+        TopmedVariable variable3 = new TopmedVariable()
+                .setVarId("var3")
+                .setMetadata(ImmutableMap.of("columnmeta_description", "Hearing loss"));
+        variable3.allTagsLowercase = ImmutableSet.of("hear", "hearing");
+
+        TopmedDataTable dataTable1 = new TopmedDataTable();
+        dataTable1.variables = ImmutableSortedMap.of(
+                "var1", variable1,
+                "var2", variable2,
+                "var3", variable3
+        );
+
+
+        TopmedVariable variable4 = new TopmedVariable()
+                .setVarId("var4")
+                .setMetadata(ImmutableMap.of("columnmeta_description", "Height"));
+        variable4.allTagsLowercase = ImmutableSet.of("height");
+        TopmedDataTable dataTable2 = new TopmedDataTable();
+
+        TopmedVariable variable5 = new TopmedVariable()
+                .setVarId("var5")
+                .setMetadata(ImmutableMap.of("columnmeta_description", "Blood Type"))
+                .setValues(ImmutableList.of("A","B", "AB","O"));
+        variable5.allTagsLowercase = ImmutableSet.of("blood", "type", "heart");
+        dataTable2.variables = ImmutableSortedMap.of(
+                "var4", variable4,
+                "var5", variable5
+        );
+
+        dictionary.put("dataTable1", dataTable1);
+        dictionary.put("dataTable2", dataTable2);
+
+        tagSearchResource = new TagSearchResource(dictionary);
+    }
+
+    @Test
+    public void basicSearch() {
+        SearchRequest.SearchRequestBuilder builder = SearchRequest.builder();
+        builder.resourceUUID(UUID.randomUUID());
+        SearchQuery.SearchQueryBuilder searchQueryBuilder = SearchQuery.builder();
+        searchQueryBuilder.searchTerm("heart");
+        searchQueryBuilder.excludedTags(List.of());
+        searchQueryBuilder.includedTags(List.of());
+        searchQueryBuilder.offset(0);
+        searchQueryBuilder.returnTags(false);
+        builder.query(searchQueryBuilder.build());
+        SearchResults searchResults = tagSearchResource.search(builder.build());
+
+        assertEquals(searchResults.getResults().getClass(), TagSearchResponse.class);
+        TagSearchResponse tagSearchResponse = (TagSearchResponse) searchResults.getResults();
+
+        assertEquals(tagSearchResponse.getSearchResults().size(), 3);
+        assertTrue(Ordering.from(TagSearchResource.SEARCH_RESULT_COMPARATOR).isOrdered(tagSearchResponse.getSearchResults()));
+        assertTrue(tagSearchResponse.getTags().isEmpty());
+    }
+
+    @Test
+    public void basicSearchWithTags() {
+        SearchRequest.SearchRequestBuilder builder = SearchRequest.builder();
+        builder.resourceUUID(UUID.randomUUID());
+        SearchQuery.SearchQueryBuilder searchQueryBuilder = SearchQuery.builder();
+        searchQueryBuilder.searchTerm("heart");
+        searchQueryBuilder.excludedTags(List.of());
+        searchQueryBuilder.includedTags(List.of());
+        searchQueryBuilder.offset(0);
+        searchQueryBuilder.returnTags(true);
+        builder.query(searchQueryBuilder.build());
+        SearchResults searchResults = tagSearchResource.search(builder.build());
+
+        assertEquals(searchResults.getResults().getClass(), TagSearchResponse.class);
+        TagSearchResponse tagSearchResponse = (TagSearchResponse) searchResults.getResults();
+
+        assertEquals(tagSearchResponse.getSearchResults().size(), 3);
+        assertTrue(Ordering.from(TagSearchResource.SEARCH_RESULT_COMPARATOR).isOrdered(tagSearchResponse.getSearchResults()));
+    }
+
+    @Test
+    public void searchVerifyJson() throws JsonProcessingException {
+        SearchRequest.SearchRequestBuilder builder = SearchRequest.builder();
+        builder.resourceUUID(UUID.randomUUID());
+        SearchQuery.SearchQueryBuilder searchQueryBuilder = SearchQuery.builder();
+        searchQueryBuilder.searchTerm("heart");
+        searchQueryBuilder.excludedTags(List.of());
+        searchQueryBuilder.includedTags(List.of());
+        searchQueryBuilder.offset(0);
+        searchQueryBuilder.returnTags(true);
+        builder.query(searchQueryBuilder.build());
+        SearchResults searchResults = tagSearchResource.search(builder.build());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writeValueAsString(searchResults);
+        assertFalse(json.contains("\"tagMap\":"));
+    }
+
+
+    @Test
+    public void searchPartialMatch() {
+        SearchRequest.SearchRequestBuilder builder = SearchRequest.builder();
+        builder.resourceUUID(UUID.randomUUID());
+        SearchQuery.SearchQueryBuilder searchQueryBuilder = SearchQuery.builder();
+        searchQueryBuilder.searchTerm("hear");
+        searchQueryBuilder.excludedTags(List.of());
+        searchQueryBuilder.includedTags(List.of());
+        searchQueryBuilder.offset(0);
+        searchQueryBuilder.returnTags(true);
+        builder.query(searchQueryBuilder.build());
+        SearchResults searchResults = tagSearchResource.search(builder.build());
+
+        assertEquals(searchResults.getResults().getClass(), TagSearchResponse.class);
+        TagSearchResponse tagSearchResponse = (TagSearchResponse) searchResults.getResults();
+
+        assertEquals(tagSearchResponse.getSearchResults().size(), 4);
+        // there should only be one exact match, which has a score of more than 100
+        assertEquals(tagSearchResponse.getSearchResults().stream().filter(searchResult -> searchResult.getScore() >= 100).count(), 1);
+
+        assertTrue(Ordering.from(TagSearchResource.SEARCH_RESULT_COMPARATOR).isOrdered(tagSearchResponse.getSearchResults()));
+        assertNotNull(tagSearchResponse.getTags());
+    }
+
+    @Test
+    public void searchLimitVariableValues1() {
+        SearchRequest.SearchRequestBuilder builder = SearchRequest.builder();
+        builder.resourceUUID(UUID.randomUUID());
+        SearchQuery.SearchQueryBuilder searchQueryBuilder = SearchQuery.builder();
+        searchQueryBuilder.searchTerm("blood");
+        searchQueryBuilder.excludedTags(List.of());
+        searchQueryBuilder.includedTags(List.of());
+        searchQueryBuilder.offset(0);
+        searchQueryBuilder.returnTags(false);
+        searchQueryBuilder.variableValuesLimit(1);
+        builder.query(searchQueryBuilder.build());
+        SearchResults searchResults = tagSearchResource.search(builder.build());
+
+        assertEquals(searchResults.getResults().getClass(), TagSearchResponse.class);
+        TagSearchResponse tagSearchResponse = (TagSearchResponse) searchResults.getResults();
+
+        tagSearchResponse.getSearchResults().forEach(searchResult -> {
+            assertEquals(searchResult.getResult().getValues().size(), 1);
+        });
+    }
+
+    @Test
+    public void searchLimitVariableValues0() {
+        SearchRequest.SearchRequestBuilder builder = SearchRequest.builder();
+        builder.resourceUUID(UUID.randomUUID());
+        SearchQuery.SearchQueryBuilder searchQueryBuilder = SearchQuery.builder();
+        searchQueryBuilder.searchTerm("blood");
+        searchQueryBuilder.excludedTags(List.of());
+        searchQueryBuilder.includedTags(List.of());
+        searchQueryBuilder.offset(0);
+        searchQueryBuilder.returnTags(false);
+        searchQueryBuilder.variableValuesLimit(0);
+        builder.query(searchQueryBuilder.build());
+        SearchResults searchResults = tagSearchResource.search(builder.build());
+
+        assertEquals(searchResults.getResults().getClass(), TagSearchResponse.class);
+        TagSearchResponse tagSearchResponse = (TagSearchResponse) searchResults.getResults();
+
+        tagSearchResponse.getSearchResults().forEach(searchResult -> {
+            assertEquals(searchResult.getResult().getValues().size(), 0);
+        });
+    }
+
+    @Test
+    public void searchLimitVariableValuesNull() {
+        SearchRequest.SearchRequestBuilder builder = SearchRequest.builder();
+        builder.resourceUUID(UUID.randomUUID());
+        SearchQuery.SearchQueryBuilder searchQueryBuilder = SearchQuery.builder();
+        searchQueryBuilder.searchTerm("blood");
+        searchQueryBuilder.excludedTags(List.of());
+        searchQueryBuilder.includedTags(List.of());
+        searchQueryBuilder.offset(0);
+        searchQueryBuilder.returnTags(false);
+        builder.query(searchQueryBuilder.build());
+        SearchResults searchResults = tagSearchResource.search(builder.build());
+
+        assertEquals(searchResults.getResults().getClass(), TagSearchResponse.class);
+        TagSearchResponse tagSearchResponse = (TagSearchResponse) searchResults.getResults();
+
+        // No variableValues specified should return all values
+        tagSearchResponse.getSearchResults().forEach(searchResult -> {
+            assertEquals(searchResult.getResult().getValues().size(), 4);
+        });
+    }
+}


### PR DESCRIPTION
* Add a parameter to `SearchQuery` to limit variable values returned
* Add code in resource to limit values in the response
* Add copy method to `TopmedVariable` to avoid modifying cached copies
* On startup, remove redundant "values" entry from `TopmedVariable.metadata`